### PR TITLE
Fix Dockerfile and add non-root USER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:alpine as glide
 RUN apk update
 RUN apk add git
-RUN go get github.com/Masterminds/glide
-WORKDIR /go/src/github.com/jirwin/burrow_exporter
 COPY . /go/src/github.com/jirwin/burrow_exporter
-RUN glide install
+WORKDIR /go/src/github.com/jirwin/burrow_exporter
 RUN go build burrow-exporter.go
 
 FROM alpine
+RUN adduser -D burrow
+USER burrow
 COPY --from=glide /go/src/github.com/jirwin/burrow_exporter/burrow-exporter .
 ENV BURROW_ADDR http://localhost:8000
 ENV METRICS_ADDR 0.0.0.0:8080


### PR DESCRIPTION
In reference to https://yexttest.atlassian.net/browse/VULN-36959, this PR fixes the broken Dockerfile (which is trying to use Glide), and runs the container process as a non-root user.